### PR TITLE
remove mimetypes

### DIFF
--- a/crates/rnote-ui/src/dialogs/export.rs
+++ b/crates/rnote-ui/src/dialogs/export.rs
@@ -22,7 +22,7 @@ use std::rc::Rc;
 
 pub(crate) async fn dialog_save_doc_as(appwindow: &RnAppWindow, canvas: &RnCanvas) {
     let filter = FileFilter::new();
-    filter.add_mime_type("application/rnote");
+    filter.add_pattern("*.rnote");
     filter.add_suffix("rnote");
     filter.set_name(Some(&gettext(".rnote")));
 
@@ -278,17 +278,17 @@ fn create_filedialog_export_doc(
     let filter = FileFilter::new();
     match doc_export_prefs.export_format {
         DocExportFormat::Svg => {
-            filter.add_mime_type("image/svg+xml");
+            filter.add_pattern("*.svg");
             filter.add_suffix("svg");
             filter.set_name(Some(&gettext("Svg")));
         }
         DocExportFormat::Pdf => {
-            filter.add_mime_type("application/pdf");
+            filter.add_pattern("*.pdf");
             filter.add_suffix("pdf");
             filter.set_name(Some(&gettext("Pdf")));
         }
         DocExportFormat::Xopp => {
-            filter.add_mime_type("application/x-xopp");
+            filter.add_pattern("*.xopp");
             filter.add_suffix("xopp");
             filter.set_name(Some(&gettext("Xopp")));
         }
@@ -583,27 +583,23 @@ fn create_filedialog_export_doc_pages(
     filter.add_mime_type("inode/directory");
     match doc_pages_export_prefs.export_format {
         DocPagesExportFormat::Svg => {
-            filter.add_mime_type("image/svg+xml");
+            filter.add_pattern("*.svg");
             filter.add_suffix("svg");
             filter.set_name(Some(&gettext("Svg")));
         }
         DocPagesExportFormat::Png => {
-            filter.add_mime_type("image/png");
+            filter.add_pattern("*.png");
             filter.add_suffix("png");
             filter.set_name(Some(&gettext("Png")));
         }
         DocPagesExportFormat::Jpeg => {
-            filter.add_mime_type("image/jpeg");
+            filter.add_pattern("*.jpg");
+            filter.add_pattern("*.jpeg");
             filter.add_suffix("jpg");
             filter.add_suffix("jpeg");
             filter.set_name(Some(&gettext("Jpeg")));
         }
     }
-
-    let filter_list = gio::ListStore::new::<FileFilter>();
-    filter_list.append(&filter);
-    filedialog.set_filters(Some(&filter_list));
-
     filedialog.set_default_filter(Some(&filter));
 
     filedialog
@@ -874,17 +870,18 @@ fn create_filedialog_export_selection(
     let filter = FileFilter::new();
     match selection_export_prefs.export_format {
         SelectionExportFormat::Svg => {
-            filter.add_mime_type("image/svg+xml");
+            filter.add_pattern("*.svg");
             filter.add_suffix("svg");
             filter.set_name(Some(&gettext("Svg")));
         }
         SelectionExportFormat::Png => {
-            filter.add_mime_type("image/png");
+            filter.add_pattern("*.png");
             filter.add_suffix("png");
             filter.set_name(Some(&gettext("Png")));
         }
         SelectionExportFormat::Jpeg => {
-            filter.add_mime_type("image/jpeg");
+            filter.add_pattern("*.jpg");
+            filter.add_pattern("*.jpeg");
             filter.add_suffix("jpg");
             filter.add_suffix("jpeg");
             filter.set_name(Some(&gettext("Jpeg")));
@@ -909,7 +906,7 @@ fn create_filedialog_export_selection(
 
 pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, canvas: &RnCanvas) {
     let filter = FileFilter::new();
-    filter.add_mime_type("application/json");
+    filter.add_pattern("*.json");
     filter.add_suffix("json");
     filter.set_name(Some(&gettext("Json")));
 
@@ -962,7 +959,7 @@ pub(crate) async fn filechooser_export_engine_state(appwindow: &RnAppWindow, can
 
 pub(crate) async fn filechooser_export_engine_config(appwindow: &RnAppWindow, canvas: &RnCanvas) {
     let filter = FileFilter::new();
-    filter.add_mime_type("application/json");
+    filter.add_pattern("*.json");
     filter.add_suffix("json");
     filter.set_name(Some(&gettext("Json")));
 

--- a/crates/rnote-ui/src/dialogs/import.rs
+++ b/crates/rnote-ui/src/dialogs/import.rs
@@ -16,8 +16,8 @@ use rnote_engine::engine::import::{PdfImportPageSpacing, PdfImportPagesType};
 /// Opens a new rnote save file in a new tab
 pub(crate) async fn filedialog_open_doc(appwindow: &RnAppWindow) {
     let filter = FileFilter::new();
-    filter.add_mime_type("application/rnote");
     filter.add_suffix("rnote");
+    filter.add_pattern("*.rnote");
     filter.set_name(Some(&gettext(".rnote")));
 
     let filter_list = gio::ListStore::new::<FileFilter>();
@@ -51,12 +51,12 @@ pub(crate) async fn filedialog_open_doc(appwindow: &RnAppWindow) {
 
 pub(crate) async fn filedialog_import_file(appwindow: &RnAppWindow) {
     let filter = FileFilter::new();
-    filter.add_mime_type("application/x-xopp");
-    filter.add_mime_type("application/pdf");
-    filter.add_mime_type("image/svg+xml");
-    filter.add_mime_type("image/png");
-    filter.add_mime_type("image/jpeg");
-    filter.add_mime_type("text/plain");
+    filter.add_pattern("*.xopp");
+    filter.add_pattern("*.pdf");
+    filter.add_pattern("*.svg");
+    filter.add_pattern("*.png");
+    filter.add_pattern("*.jpeg");
+    filter.add_pattern("*.txt");
     filter.add_suffix("xopp");
     filter.add_suffix("pdf");
     filter.add_suffix("svg");

--- a/crates/rnote-ui/src/workspacebrowser/mod.rs
+++ b/crates/rnote-ui/src/workspacebrowser/mod.rs
@@ -460,7 +460,7 @@ fn create_folders_sorter() -> MultiSorter {
 
 fn create_notes_filter() -> EveryFilter {
     let file_filter = FileFilter::new();
-    file_filter.add_mime_type("application/rnote");
+    file_filter.add_pattern("*.rnote");
     file_filter.add_suffix("rnote");
     let hidden_filter = create_hidden_filter();
 
@@ -478,12 +478,12 @@ fn create_notes_sorter() -> MultiSorter {
 
 fn create_files_filter() -> EveryFilter {
     let file_filter = FileFilter::new();
-    file_filter.add_mime_type("application/pdf");
-    file_filter.add_mime_type("application/x-xopp");
-    file_filter.add_mime_type("image/svg+xml");
-    file_filter.add_mime_type("image/png");
-    file_filter.add_mime_type("image/jpeg");
-    file_filter.add_mime_type("text/plain");
+    file_filter.add_pattern("*.pdf");
+    file_filter.add_pattern("*.xopp");
+    file_filter.add_pattern("*.svg");
+    file_filter.add_pattern("*.png");
+    file_filter.add_pattern("*.jpeg");
+    file_filter.add_pattern("*.plain");
     file_filter.add_suffix("pdf");
     file_filter.add_suffix("xopp");
     file_filter.add_suffix("svg");


### PR DESCRIPTION
this allows for the filepicker to stay as the native one on windows and, this makes the extension automatically apply on both windows and linux even if the file name doesn't include the extension.