### PR TITLE
workaround for windows ink

### DIFF
--- a/crates/rnote-ui/src/canvas/input.rs
+++ b/crates/rnote-ui/src/canvas/input.rs
@@ -119,7 +119,14 @@ pub(crate) fn handle_pointer_controller_event(
                 if gdk_button == gdk::BUTTON_PRIMARY {
                     pen_state = PenState::Up;
                 } else {
-                    pen_state = PenState::Proximity;
+                    #[cfg(target_os = "windows")]
+                    {
+                        pen_state = PenState::Up;
+                    }
+                    #[cfg(not(target_os = "windows"))]
+                    {
+                        pen_state = PenState::Proximity;
+                    }
                 }
             } else {
                 #[allow(clippy::collapsible_else_if)]
@@ -167,6 +174,13 @@ pub(crate) fn handle_pointer_controller_event(
 
         for (element, event_time) in elements {
             tracing::trace!("handle pen event element - element: {element:?}, pen_state: {pen_state:?}, event_time_delta: {:?}, modifier_keys: {modifier_keys:?}, pen_mode: {pen_mode:?}", now.duration_since(event_time));
+
+            #[cfg(target_os = "windows")]
+            {
+                if element.pressure > 0.0 && is_stylus {
+                    pen_state = PenState::Down;
+                }
+            }
 
             match pen_state {
                 PenState::Up => {


### PR DESCRIPTION
- force down state when the element is a stylus with a pressure value that is not zero. This way when a button is pressed before the pen is on the screen, this triggers proximity mode as rnote expects a left click when the pen touches the screen

- forces a pen state to up upon a button release as once again we have our button as a buttonrelease instead of the left click or BUTTON_PRIMARY release